### PR TITLE
Fix inspection plots

### DIFF
--- a/inspection_plots/inspection_plots.py
+++ b/inspection_plots/inspection_plots.py
@@ -29,21 +29,21 @@ def get_inspection_plot_list(is_calibrator=False):
         plot_type_list = ['_beams_xx',
                           '_beams_yy']
     else:
-        plot_type_list = ['_beams_ampvstime',
-                          '_beams_ampvschan',
-                          '_beams_phavstime',
-                          '_beams_phavschan',
-                          '_beams_waterfall_amplitude_autoscale',
-                          '_beams_waterfall_amplitude_noscale',
-                          '_beams_waterfall_phase_autoscale',
-                          '_beams_waterfall_amplitude_noscale',
+        plot_type_list = ['_beams_ampvstime_XX',
+                          '_beams_ampvschan_XX',
+                          '_beams_phavstime_XX',
+                          '_beams_phavschan_XX',
+                          '_beams_waterfall_amplitude_autoscale_XX',
+                          '_beams_waterfall_amplitude_noscale_XX',
+                          '_beams_waterfall_phase_autoscale_XX',
+                          '_beams_waterfall_amplitude_noscale_XX',
                           '_beams_xx',
                           '_beams_yy']
 
     return plot_type_list
 
 
-def get_inspection_plot_from_alta(qa_plot_dir, obs_id, plot_type):
+def get_inspection_plot_from_alta(qa_plot_dir, obs_id, plot_type_list):
     """
     Function to get a specific inspection plot from ALTA
 
@@ -62,26 +62,69 @@ def get_inspection_plot_from_alta(qa_plot_dir, obs_id, plot_type):
     # Path of inspection plots on ALTA for a given obs id
     alta_plot_path = os.path.join(default_alta_path, "{}_INSP".format(obs_id))
 
-    plot_file_name = "WSRTA{0}{1}.png".format(obs_id, plot_type)
+    plot_file_name_list = ["WSRTA{0}{1}.png".format(
+        obs_id, plot_type) for plot_type in plot_type_list]
 
-    alta_plot_file = os.path.join(alta_plot_path, plot_file_name)
+    alta_plot_file_list = [os.path.join(
+        alta_plot_path, plot_file_name) for plot_file_name in plot_file_name_list]
+
+    alta_files = " ".join(alta_plot_file_list)
+
+    # set the irod files location
+    irods_status_file = os.path.join(
+        qa_plot_dir, "{}_insp-icat.irods-status".format(obs_id))
+
+    irods_status_lf_file = os.path.join(
+        qa_plot_dir, "{}_insp-icat.lf-irods-status".format(obs_id))
 
     # iget command to get the plot
     try:
-        cmd = "iget -fPIT {0} {1}".format(
-            alta_plot_file, qa_plot_dir)
+        cmd = "iget -rfPIT -X {0} --lfrestart {1} --retries 5 {2} {3}".format(
+            irods_status_file, irods_status_lf_file, alta_files, qa_plot_dir)
         logger.debug(cmd)
         subprocess.check_call(cmd, shell=True, stdout=FNULL, stderr=FNULL)
     except Exception as e:
-        logger.warning("Failed retrieving {}".format(alta_plot_file))
+        logger.warning(
+            "Failed retrieving inpsection plots for {}".format(obs_id))
         logger.exception(e)
     else:
-        logger.info("Successully retrieved {}".format(alta_plot_file))
+        logger.info(
+            "Successully retrieved inspection plots for {}".format(obs_id))
+
+    # iget -rfPIT -X /data/schulz/transfer_files/test-icat.irods-status --lfrestart /data/schulz/transfer_files/test-icat.lf-irods-status --retries 5 /altaZone/home/apertif_main/early_results/temp_storage/190725042/17/M0155+3130.UVFITS /data/schulz
 
     # return full path
     # plot_file_name_with_path = os.path.join(qa_plot_dir, plot_file_name)
 
-    return plot_file_name
+    return plot_file_name_list
+
+
+def rename_inspection_plots(qa_plot_dir, plot_file_name_list):
+    """
+    Function to rename the inspection plots from the target so that 
+    they stay in order.
+    """
+
+    plot_counter = 1
+
+    for plot_file_name in plot_file_name_list:
+        # rename it to keep the order
+        plot_file_name_new = os.path.join(qa_plot_dir, "{0:02d}_{1:s}".format(
+            plot_counter, plot_file_name))
+
+        # have to add the path to the original plot name now
+        plot_file_name = os.path.join(qa_plot_dir, plot_file_name)
+
+        try:
+            os.rename(plot_file_name, plot_file_name_new)
+        except Exception as e:
+            logger.warning("Renaming {} failed".format(plot_file_name))
+            logger.exception(e)
+        else:
+            logger.info("Inspection plot saved as {0:s}".format(
+                os.path.basename(plot_file_name_new)))
+
+        plot_counter += 1
 
 
 def get_inspection_plots(obs_id, qa_plot_dir, is_calibrator=False, cal_id=None):
@@ -93,46 +136,15 @@ def get_inspection_plots(obs_id, qa_plot_dir, is_calibrator=False, cal_id=None):
         obs_id (int) ID of observation (scan number or task id)
     """
 
-    # list of polarizations, currently one, but just in case
-    polarization_list = ['XX']
-
     # list of types of inspection plots
     plot_type_list = get_inspection_plot_list(is_calibrator=is_calibrator)
 
-    plot_counter = 1
+    # get inspection plot
+    if cal_id is None:
+        plot_file_name_list = get_inspection_plot_from_alta(
+            qa_plot_dir, obs_id, plot_type_list)
 
-    # go through the polarzation
-    for polarization in polarization_list:
-
-        # go through each plot type to retrieve the plot from ALTA
-        for plot_type in plot_type_list:
-
-            if plot_type != "_beams_xx" and plot_type != "_beams_yy":
-                plot_type += "_{}".format(polarization)
-
-            # get inspection plot
-            if cal_id is None:
-                plot_file_name = get_inspection_plot_from_alta(
-                    qa_plot_dir, obs_id, plot_type)
-            else:
-                plot_file_name = get_inspection_plot_from_alta(
-                    qa_plot_dir, cal_id, plot_type)
-
-            # rename it to keep the order
-            if not is_calibrator:
-                plot_file_name_new = os.path.join(qa_plot_dir, "{0:02d}_{1:s}".format(
-                    plot_counter, plot_file_name))
-
-                # have to add the path to the original plot name now
-                plot_file_name = os.path.join(qa_plot_dir, plot_file_name)
-
-                try:
-                    os.rename(plot_file_name, plot_file_name_new)
-                except Exception as e:
-                    logger.warning("Renaming {} failed".format(plot_file_name))
-                    logger.exception(e)
-                else:
-                    logger.info("Inspection plot saved as {0:s}".format(
-                        os.path.basename(plot_file_name_new)))
-
-            plot_counter += 1
+        rename_inspection_plots(qa_plot_dir, plot_file_name_list)
+    else:
+        plot_file_name_list = get_inspection_plot_from_alta(
+            qa_plot_dir, cal_id, plot_type_list)

--- a/inspection_plots/inspection_plots.py
+++ b/inspection_plots/inspection_plots.py
@@ -36,7 +36,7 @@ def get_inspection_plot_list(is_calibrator=False):
                           '_beams_waterfall_amplitude_autoscale_XX',
                           '_beams_waterfall_amplitude_noscale_XX',
                           '_beams_waterfall_phase_autoscale_XX',
-                          '_beams_waterfall_amplitude_noscale_XX',
+                          '_beams_waterfall_phase_noscale_XX',
                           '_beams_xx',
                           '_beams_yy']
 

--- a/run_qa.py
+++ b/run_qa.py
@@ -186,7 +186,7 @@ def run_triggered_qa(targets, fluxcals, polcals, steps=None, basedir=None, osa='
         # for the flux and pol calibrator, they have to be run on every node
 
         # get inspection plots for target
-        if host_name == "happili-01" or host_name == "happili-05":
+        if host_name == "happili-01":
 
             logger.info(
                 "#### Inspection plot QA for {}...".format(name_target))

--- a/run_qa.py
+++ b/run_qa.py
@@ -193,7 +193,7 @@ def run_triggered_qa(targets, fluxcals, polcals, steps=None, basedir=None, osa='
 
             try:
                 inspection_plot_msg = os.system(
-                    'python /home/schulz/apercal/dataqa/run_inspection_plot.py {0:d} {1:s}'.format(taskid_target, name_target))
+                    'python /home/apercal/dataqa/run_inspection_plot.py {0:d} {1:s}'.format(taskid_target, name_target))
                 logger.info(
                     "Getting inspection plots finished with msg {0}".format(inspection_plot_msg))
                 logger.info(
@@ -210,7 +210,7 @@ def run_triggered_qa(targets, fluxcals, polcals, steps=None, basedir=None, osa='
 
             try:
                 inspection_plot_msg = os.system(
-                    'python /home/schulz/apercal/dataqa/run_inspection_plot.py {0:d} {1:s} -c --beam={2:d} --cal_id={3:d}'.format(taskid_target, name_fluxcal, beamnr_cal, taskid_cal))
+                    'python /home/apercal/dataqa/run_inspection_plot.py {0:d} {1:s} -c --beam={2:d} --cal_id={3:d}'.format(taskid_target, name_fluxcal, beamnr_cal, taskid_cal))
                 logger.info(
                     "Getting inspection plots finished with msg {0}".format(inspection_plot_msg))
                 logger.info("#### Inspection plot QA for {0} beam {1} ... Done".format(
@@ -229,7 +229,7 @@ def run_triggered_qa(targets, fluxcals, polcals, steps=None, basedir=None, osa='
 
                 try:
                     inspection_plot_msg = os.system(
-                        'python /home/schulz/apercal/dataqa/run_inspection_plot.py {0:d} {1:s} -c --beam={2:d} --cal_id={3:d}'.format(taskid_target, name_polcal, beamnr_cal, taskid_cal))
+                        'python /home/apercal/dataqa/run_inspection_plot.py {0:d} {1:s} -c --beam={2:d} --cal_id={3:d}'.format(taskid_target, name_polcal, beamnr_cal, taskid_cal))
                     logger.info(
                         "Getting inspection plots finished with msg {0}".format(inspection_plot_msg))
                     logger.info("#### Inspection plot QA for {0} beam {1} ... Done".format(

--- a/run_qa.py
+++ b/run_qa.py
@@ -193,7 +193,7 @@ def run_triggered_qa(targets, fluxcals, polcals, steps=None, basedir=None, osa='
 
             try:
                 inspection_plot_msg = os.system(
-                    'python /home/apercal/dataqa/run_inspection_plot.py {0:d} {1:s}'.format(taskid_target, name_target))
+                    'python /home/schulz/apercal/dataqa/run_inspection_plot.py {0:d} {1:s}'.format(taskid_target, name_target))
                 logger.info(
                     "Getting inspection plots finished with msg {0}".format(inspection_plot_msg))
                 logger.info(
@@ -210,7 +210,7 @@ def run_triggered_qa(targets, fluxcals, polcals, steps=None, basedir=None, osa='
 
             try:
                 inspection_plot_msg = os.system(
-                    'python /home/apercal/dataqa/run_inspection_plot.py {0:d} {1:s} -c --beam={2:d} --cal_id={3:d}'.format(taskid_target, name_fluxcal, beamnr_cal, taskid_cal))
+                    'python /home/schulz/apercal/dataqa/run_inspection_plot.py {0:d} {1:s} -c --beam={2:d} --cal_id={3:d}'.format(taskid_target, name_fluxcal, beamnr_cal, taskid_cal))
                 logger.info(
                     "Getting inspection plots finished with msg {0}".format(inspection_plot_msg))
                 logger.info("#### Inspection plot QA for {0} beam {1} ... Done".format(
@@ -229,7 +229,7 @@ def run_triggered_qa(targets, fluxcals, polcals, steps=None, basedir=None, osa='
 
                 try:
                     inspection_plot_msg = os.system(
-                        'python /home/apercal/dataqa/run_inspection_plot.py {0:d} {1:s} -c --beam={2:d} --cal_id={3:d}'.format(taskid_target, name_polcal, beamnr_cal, taskid_cal))
+                        'python /home/schulz/apercal/dataqa/run_inspection_plot.py {0:d} {1:s} -c --beam={2:d} --cal_id={3:d}'.format(taskid_target, name_polcal, beamnr_cal, taskid_cal))
                     logger.info(
                         "Getting inspection plots finished with msg {0}".format(inspection_plot_msg))
                     logger.info("#### Inspection plot QA for {0} beam {1} ... Done".format(

--- a/run_qa.py
+++ b/run_qa.py
@@ -186,7 +186,7 @@ def run_triggered_qa(targets, fluxcals, polcals, steps=None, basedir=None, osa='
         # for the flux and pol calibrator, they have to be run on every node
 
         # get inspection plots for target
-        if host_name == "happili-01":
+        if host_name == "happili-01" or host_name == "happili-05":
 
             logger.info(
                 "#### Inspection plot QA for {}...".format(name_target))


### PR DESCRIPTION
Changed how inspection plots are pulled from ALTA. Now, it uses restart and irods-status files similar to how MS files are pulled. Also, files to be pulled for a single call are grouped together. This should increase stability.